### PR TITLE
Add CI for package

### DIFF
--- a/.rdmanifest
+++ b/.rdmanifest
@@ -1,0 +1,14 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/center_of_mass'
+depends:
+- urdfdom_py
+- rospy
+- bitbots_docs
+exec-path: center_of_mass-master
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/center_of_mass'
+uri: https://github.com/bit-bots/center_of_mass/archive/refs/heads/master.tar.gz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,7 @@
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
+
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("center_of_mass", ".")))
+pipeline.execute()


### PR DESCRIPTION
## Proposed changes
This PR adds an `.rdmanifest` file so that this package is installable in CI via rosdep.
It also configures CI to run for this package.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

